### PR TITLE
Fix tutorial directory step

### DIFF
--- a/docs/_notebook/general/Setup_Pangeo_environment_Gadi.ipynb
+++ b/docs/_notebook/general/Setup_Pangeo_environment_Gadi.ipynb
@@ -104,7 +104,7 @@
     "First create a directory where you will run the jupyter notebook:\n",
     "\n",
     "```\n",
-    "$ mkdir ~/pangeo/tutorial\n",
+    "$ mkdir -p ~/pangeo/tutorial\n",
     "\n",
     "```\n",
     "You can create a shell script by copying the following commands into a script file. Let’s name this file run_ipynb_job.sh:\n",


### PR DESCRIPTION
If '~/pangeo/' doesn't exist this will give an error. Added `-p` switch to make the directories recursively.